### PR TITLE
Increase size of data partition

### DIFF
--- a/board/raspberrypi/genimage.cfg
+++ b/board/raspberrypi/genimage.cfg
@@ -6,7 +6,7 @@ image data.ext4 {
 		label = "Data"
 		features = "^64bit"
 	}
-	size = 128M
+	size = 50G
 }
 
 image upload.ext4 {
@@ -62,7 +62,7 @@ image sdcard.img {
 	partition data {
 		partition-type = 0x83
 		image = "data.ext4"
-		size = 128M
+		size = 50G
 	}
 
 	partition rootfs0 {


### PR DESCRIPTION
Increase the size of the `data` partition to allow us more space on the disk - our onlogic is supplied with a 64GB disk.